### PR TITLE
Watcher compatibility

### DIFF
--- a/flycheck-eldev.el
+++ b/flycheck-eldev.el
@@ -257,23 +257,16 @@ If FROM is nil, search from `default-directory'."
               ;; `eldev-project-main-file' is specified, this does nothing.
               "--setup-first"
               ,(flycheck-sexp-to-string
-                `(advice-add #'eldev--package-dir-info :around
+                `(advice-add #'eldev-package-descriptor :around
                              (lambda (original)
                                (eldev-advised
                                 (#'insert-file-contents
                                  :around (lambda (original filename &rest arguments)
                                            (if (file-equal-p filename ,real-filename)
-                                               (when ,flycheck-eldev-outside-temp-files
-                                                 ;; Load the temp file instead.
-                                                 (apply original ,filename arguments))
+                                               ;; Load the temp file instead.
+                                               (apply original ,filename arguments)
                                              (apply original filename arguments))))
                                 (funcall original)))))
-              ;; When checking project's main file, use the temporary as the main file
-              ;; instead.
-              "--setup"
-              ,(flycheck-sexp-to-string
-                `(when (and eldev-project-main-file (file-equal-p eldev-project-main-file ,real-filename))
-                   (setf eldev-project-main-file ,filename)))
               ;; Special handling for test files: load extra dependencies as if testing
               ;; now.  Likewise for loading roots.
               "--setup"

--- a/flycheck-eldev.el
+++ b/flycheck-eldev.el
@@ -1,6 +1,6 @@
 ;;; flycheck-eldev.el --- Eldev support in Flycheck  -*- lexical-binding: t -*-
 
-;;; Copyright (C) 2020-2023 Paul Pogonyshev
+;;; Copyright (C) 2020-2025 Paul Pogonyshev
 
 ;; Author:     Paul Pogonyshev <pogonyshev@gmail.com>
 ;; Maintainer: Paul Pogonyshev <pogonyshev@gmail.com>

--- a/test/flycheck-eldev-test.el
+++ b/test/flycheck-eldev-test.el
@@ -101,13 +101,13 @@
 
 
 (flycheck-eldev-ert-defargtest flycheck-eldev-basics-1 (file)
-                               ("project-a/project-a.el" "project-b/project-b.el" "project-b/project-b-util.el")
+                               ("project-a/project-a.el" "project-b/project-b.el" "project-b/project-b-util.el" "project-c/project-c.el" "project-c/project-c-util.el")
   (flycheck-eldev--test file
     (flycheck-eldev--test-recheck)
     (flycheck-eldev--test-expect-no-errors)))
 
 (flycheck-eldev-ert-defargtest flycheck-eldev-basics-2 (file)
-                               ("project-a/Eldev" "project-b/Eldev")
+                               ("project-a/Eldev" "project-b/Eldev" "project-c/Eldev")
   (flycheck-eldev--test file
     ;; Enable `checkdoc'.  Must be disabled at runtime (currently through our own hack)
     ;; for the test to pass.
@@ -137,7 +137,9 @@
     (flycheck-eldev--test-expect-no-errors)))
 
 (flycheck-eldev-ert-defargtest flycheck-eldev-test-file-1 (file)
-                               ("project-a/test/project-a.el" "project-b/test/project-b.el" "project-b/test/project-b-util.el")
+                               ("project-a/test/project-a.el"
+                                "project-b/test/project-b.el" "project-b/test/project-b-util.el"
+                                "project-c/test/project-c.el" "project-c/test/project-c-util.el")
   (flycheck-eldev--test file
     (flycheck-eldev--test-recheck)
     (flycheck-eldev--test-expect-no-errors)))
@@ -149,12 +151,15 @@
       (flycheck-eldev--test-expect-errors '(:matches "dependency-a")))))
 
 ;; Test that removing dependencies gives errors immediately.
-(ert-deftest flycheck-eldev-remove-dependency-1 ()
-  (flycheck-eldev--test "project-a/project-a.el"
-    (search-forward "(dependency-a \"1.0\")")
+(flycheck-eldev-ert-defargtest flycheck-eldev-remove-dependency-1 (file dependency)
+                               (("project-a/project-a.el" 'dependency-a)
+                                ("project-b/project-b.el" 'dependency-b)
+                                ("project-c/project-c.el" 'dependency-b))
+  (flycheck-eldev--test file
+    (re-search-forward (format "(%s \"[^\"]+\")" dependency))
     (replace-match "")
     (flycheck-eldev--test-recheck)
-    (flycheck-eldev--test-expect-errors '(:matches "dependency-a"))))
+    (flycheck-eldev--test-expect-errors `(:matches ,(symbol-name dependency)))))
 
 ;; Test that adding unaccessible dependencies gives errors immediately.
 (ert-deftest flycheck-eldev-add-dependency-1 ()

--- a/test/project-c/Eldev
+++ b/test/project-c/Eldev
@@ -1,0 +1,7 @@
+; -*- mode: emacs-lisp; lexical-binding: t -*-
+
+(eldev-use-package-archive `("archive-a" . ,(expand-file-name "../package-archive-a")))
+
+;; The point of this test project is to verify that explicitly set `eldev-project-main-file' still works as
+;; expected.
+(setf eldev-project-main-file "project-c.el")

--- a/test/project-c/project-c-util.el
+++ b/test/project-c/project-c-util.el
@@ -1,0 +1,9 @@
+;;; -*- lexical-binding: t; -*-
+
+(require 'dependency-a)
+(require 'dependency-b)
+
+(defun project-c-do-hello ()
+  (dependency-a-hello))
+
+(provide 'project-c-util)

--- a/test/project-c/project-c.el
+++ b/test/project-c/project-c.el
@@ -1,0 +1,24 @@
+;;; project-c.el --- Exactly like `project-b', but with explicitly set `eldev-project-main-file'  -*- lexical-binding: t; -*-
+
+;; Version: 1.0
+;; Homepage: https://example.com/
+;; Package-Requires: ((dependency-a "1.0") (dependency-b "1.0"))
+
+;;; Commentary:
+
+;; Comments to make linters happy.
+
+;;; Code:
+
+(require 'project-c-util)
+(require 'dependency-a)
+(require 'dependency-b)
+
+(defun project-c-hello ()
+  "Invoke `project-c-do-hello' from `project-c-util'.
+This docstring exists to make linters happy."
+  (project-c-do-hello))
+
+(provide 'project-c)
+
+;;; project-c.el ends here

--- a/test/project-c/test/project-c-util.el
+++ b/test/project-c/test/project-c-util.el
@@ -1,0 +1,6 @@
+;; -*- lexical-binding: t; -*-
+
+(require 'project-c)
+(require 'ert)
+
+(provide 'test/project-c-util)

--- a/test/project-c/test/project-c.el
+++ b/test/project-c/test/project-c.el
@@ -1,0 +1,6 @@
+;; -*- lexical-binding: t; -*-
+
+(require 'test/project-c-util)
+
+(ert-deftest project-c-test-hello ()
+  (should (string= (project-c-hello) "Hello")))


### PR DESCRIPTION
I implemented
`flycheck-eldev--checker-substituted-arguments` to handle the
`'source-inplace` to `'source` conversion first. Then I ran the tests
and had lots of failures. Fixing up the `--setup-first` made all the
tests green again.